### PR TITLE
Install CasaOS Users Manager as a System Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,22 @@ A Python script for managing CasaOS users directly in the `user.db` database. Fe
 
 **Note**: Requires `sudo` permissions and Python 3.x. Always backs up the database before making changes.
 
-Run the script with:
+### Run the script with:
 ```bash
 sudo python3 program.py
 ```
 
-Or build for your platform using pyinstaller:
+### Or install as a System Command:
+```bash
+sudo cp program.py /usr/bin/casaos-users-manager
+sudo chmod +x /usr/bin/casaos-users-manager
+```
+And run with
+```
+sudo casaos-users-manager
+```
+
+### Or build for your platform using pyinstaller:
 ```bash
 pip install pyinstaller
 ```

--- a/program.py
+++ b/program.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sqlite3
 import os
 import shutil


### PR DESCRIPTION
Thanks for the script! I've added a feature that allows program.py to be directly installed in the system's binary directory.
This update enables execution with a simple command: casaos-users-manager, without the need for compiling with PyInstaller.